### PR TITLE
Update fsprojs for .Net Core SDK 2

### DIFF
--- a/ItemRandomizer/ItemRandomizer.fsproj
+++ b/ItemRandomizer/ItemRandomizer.fsproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <RootNamespace>ItemRandomizer</RootNamespace>
@@ -20,9 +20,5 @@
     <Compile Include="Randomizers.fs" />
     <Compile Include="Randomizer.fs" />
     <Content Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="FSharp.Core" Version="4.1.*" />
-    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/itemrandomizerweb.fsproj
+++ b/itemrandomizerweb.fsproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -12,8 +12,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FSharp.Core" Version="4.1.*" />
-    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
     <PackageReference Include="DotLiquid" Version="2.0.145" />
     <PackageReference Include="Suave" Version="2.0.1" />
     <PackageReference Include="Suave.DotLiquid" Version="2.1.0" />


### PR DESCRIPTION
Removes FSharp.Net.SDK references in order to resolve building errors and build successfully on latest .NET Core 2 SDK.
Reference used: [https://github.com/dotnet/netcorecli-fsc/wiki/How-to-migrate-1.0-projects-to-2.0#changes-in-fsproj](https://github.com/dotnet/netcorecli-fsc/wiki/How-to-migrate-1.0-projects-to-2.0#changes-in-fsproj)